### PR TITLE
Various edits.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: python
+cache: pip
+python:
+  - "3.6"
+env:
+  - BASEDIR="https://raw.githubusercontent.com/open-contracting/standard-maintenance-scripts/master"
+install:
+  - curl -s -S --retry 3 $BASEDIR/tests/install.sh | bash -
+script:
+  - curl -s -S --retry 3 $BASEDIR/tests/script.sh | bash -

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In the European Union, this extension's fields correspond to [eForms BG-706 (Tec
   "tender": {
     "lots": [
       {
-        "id": 1,
+        "id": "1",
         "hasFrameworkAgreement": true,
         "frameworkAgreement": {
           "maximumNumberParticipants": 100,
@@ -36,7 +36,7 @@ In the European Union, this extension's fields correspond to [eForms BG-706 (Tec
   "tender": {
     "lots": [
       {
-        "id": 1,
+        "id": "1",
         "hasDynamicPurchasingSystem": true,
         "dynamicPurchasingSystem": {
           "type": "closed"
@@ -54,7 +54,7 @@ In the European Union, this extension's fields correspond to [eForms BG-706 (Tec
   "tender": {
     "lots": [
       {
-        "id": 1,
+        "id": "1",
         "hasElectronicAuction": true,
         "electronicAuction": {
           "url": "https://example.com/auction/1",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Techniques
 
-Adds fields to the tender object to describe the use of techniques, such as framework agreements without reopening of competition, framework agreements with reopening of competition, dynamic purchasing systems and electronic auctions.
+Adds fields to the lot object to describe the use of techniques, such as framework agreements without reopening of competition, framework agreements with reopening of competition, dynamic purchasing systems and electronic auctions.
 
 ## Legal context
 
@@ -13,13 +13,18 @@ In the European Union, this extension's fields correspond to [eForms BG-706 (Tec
 ```json
 {
   "tender": {
-    "hasFrameworkAgreement": true,
-    "frameworkAgreement": {
-      "maximumNumberParticipants": 100,
-      "method": "withoutReopeningCompetition",
-      "durationRationale": "<A good justification>",
-      "buyerCategories": "all hospitals in the Tuscany region"
-    }
+    "lots": [
+      {
+        "id": 1,
+        "hasFrameworkAgreement": true,
+        "frameworkAgreement": {
+          "maximumNumberParticipants": 100,
+          "method": "withoutReopeningCompetition",
+          "durationRationale": "<A good justification>",
+          "buyerCategories": "all hospitals in the Tuscany region"
+        }
+      }
+    ]
   }
 }
 ```
@@ -29,10 +34,15 @@ In the European Union, this extension's fields correspond to [eForms BG-706 (Tec
 ```json
 {
   "tender": {
-    "hasDynamicPurchasingSystem": true,
-    "dynamicPurchasingSystem": {
-      "type": "closed"
-    }
+    "lots": [
+      {
+        "id": 1,
+        "hasDynamicPurchasingSystem": true,
+        "dynamicPurchasingSystem": {
+          "type": "closed"
+        }
+      }
+    ]
   }
 }
 ```
@@ -42,11 +52,16 @@ In the European Union, this extension's fields correspond to [eForms BG-706 (Tec
 ```json
 {
   "tender": {
-    "hasElectronicAuction": true,
-    "electronicAuction": {
-      "url": "https://example.com/auction/1",
-      "description": "<Any relevant details>"
-    }
+    "lots": [
+      {
+        "id": 1,
+        "hasElectronicAuction": true,
+        "electronicAuction": {
+          "url": "https://example.com/auction/1",
+          "description": "<Any relevant details>"
+        }
+      }
+    ]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,56 @@
-#Procurement techniques extension for EU data
+# Techniques
 
-> OCDS extension to describe the Framework agreement and DPS configuration as expressed in eForms (BG-706, BT-764) and compatible with TED.
+Adds fields to the tender object to describe the use of techniques, such as framework agreements without reopening of competition, framework agreements with reopening of competition, dynamic purchasing systems and electronic auctions.
 
-This extension aims primarily at supporting the description of framework agreements, dynamic purchasing systems (DPS) and electronic catalogue formatted according to eForms data structure, but it also aims at enabling the OCDS publication of TED v2.0.9 data.
+## Legal context
+
+In the European Union, this extension's fields correspond to [eForms BG-706 (Techniques)](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+
+## Examples
+
+### Framework agreement
+
+```json
+{
+  "tender": {
+    "hasFrameworkAgreement": true,
+    "frameworkAgreement": {
+      "maximumNumberParticipants": 100,
+      "method": "withoutReopeningCompetition",
+      "durationRationale": "<A good justification>",
+      "buyerCategories": "all hospitals in the Tuscany region"
+    }
+  }
+}
+```
+
+### Dynamic purchasing system
+
+```json
+{
+  "tender": {
+    "hasDynamicPurchasingSystem": true,
+    "dynamicPurchasingSystem": {
+      "type": "closed"
+    }
+  }
+}
+```
+
+### Electronic auction
+
+```json
+{
+  "tender": {
+    "hasElectronicAuction": true,
+    "electronicAuction": {
+      "url": "https://example.com/auction/1",
+      "description": "<Any relevant details>"
+    }
+  }
+}
+```
+
+## Issues
+
+Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.

--- a/codelists/dynamicPurchasingSystem.csv
+++ b/codelists/dynamicPurchasingSystem.csv
@@ -1,3 +1,0 @@
-Code,Title,Description,Deprecated
-dpsOpen, Open Dynamic Purchasing System, A Dynamic Purchasing System is involved in the framework agreement and can be used by buyers not initially listed in the procedure,
-dpsClosed, Closed Dynamic Purchasing System, A Dynamic Purchasing System is involved in the framework agreement and cannot be used by buyers not initially listed in the procedure,

--- a/codelists/dynamicPurchasingSystemType.csv
+++ b/codelists/dynamicPurchasingSystemType.csv
@@ -1,0 +1,3 @@
+Code,Title,Description
+open,Open,The dynamic purchasing system can also be used by buyers not listed in the contracting process.
+closed,Closed,The dynamic purchasing system can only be used by buyers listed in the contracting process.

--- a/codelists/electronicCatalogue.csv
+++ b/codelists/electronicCatalogue.csv
@@ -1,4 +1,0 @@
-Code,Title,Description,Deprecated
-required,Required,The tenderers must submit (part of) their bid as an electronic catalogue,
-allowed,Allowed,The tenderers are allowed to submit (part of) their bid as an electronic catalogue,
-notAllowed,Not allowed,The tenderers are not allowed to submit (part of) their bid as an electronic catalogue,

--- a/codelists/frameworkAgreementCompetition.csv
+++ b/codelists/frameworkAgreementCompetition.csv
@@ -1,4 +1,0 @@
-Code,Title,Description,Deprecated
-withReopening,With reopening of the competition,The competition is reopened for each subsequent contract of the framework agreement.,
-withoutReopening,Without reopening of the competition,The competition is not reopened for each subsequent contract of the framework agreement.,
-withOrWithoutReopening,With or without reopening of the competition,The competition may or may not be reopened for each subsequent contract of the framework agreement.,

--- a/codelists/frameworkAgreementMethod.csv
+++ b/codelists/frameworkAgreementMethod.csv
@@ -1,0 +1,4 @@
+Code,Title,Description
+withReopeningCompetition,With reopening of competition,Contracts are awarded by reopening the competition (e.g. mini-competition or mini-tender).
+withoutReopeningCompetition,Without reopening of competition,Contracts are awarded without the reopening of competition (e.g. direct call-off or direct award).
+withAndWithoutReopeningCompetition,With and without reopening of competition,Contracts are awarded both with and without the reopening of competition.

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
     "en": "Techniques"
   },
   "description": {
-    "en": "Adds fields to the tender object to describe the use of techniques, such as framework agreements without reopening of competition, framework agreements with reopening of competition, dynamic purchasing systems and electronic auctions."
+    "en": "Adds fields to the lot object to describe the use of techniques, such as framework agreements without reopening of competition, framework agreements with reopening of competition, dynamic purchasing systems and electronic auctions."
   },
   "documentationUrl": {
     "en": "https://github.com/open-contracting-extensions/ocds_techniques_extension"

--- a/extension.json
+++ b/extension.json
@@ -1,22 +1,24 @@
 {
   "name": {
-    "en": "EU procurement techniques"
+    "en": "Techniques"
   },
   "description": {
-    "en": "This extension aims primarily at supporting the description of framework agreements  (FA) and dynamic purchasing systems (DPS) formatted according to eForms data structure, but it also aims at enabling the OCDS publication of TED v2.0.9 data."
+    "en": "Adds fields to the tender object to describe the use of techniques, such as framework agreements without reopening of competition, framework agreements with reopening of competition, dynamic purchasing systems and electronic auctions."
   },
   "documentationUrl": {
-    "en": "https://github.com/open-contracting-extensions/ocds_procurement_techniques_extension"
+    "en": "https://github.com/open-contracting-extensions/ocds_techniques_extension"
   },
   "compatibility": [
     "1.1"
   ],
   "schemas": [
     "release-schema.json"
-],
-"codelists": [
-    "dynamicPurchasingSystem.csv",
-    "frameworkAgreementCompetition.csv",
-    "electronicCatalogue.csv"
-]
+  ],
+  "codelists": [
+    "dynamicPurchasingSystemType.csv",
+    "frameworkAgreementMethod.csv"
+  ],
+  "dependencies": [
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+  ]
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -1,89 +1,138 @@
 {
   "definitions": {
-    "Tender": {
+    "Lot": {
       "properties": {
-        "frameworkAgreement": {
-          "title": "Framework agreement",
-          "description": "The details of the framework agreement",
-          "type": "object",
-          "properties": {
-            "maximumNumberSelectedTenderers": {
-              "title": "Maximum number of selected tenderers",
-              "description": "The maximum number of tenderers that may be awarded a contract in the framework agreement. Set to 0 for an unlimited number of tenderers.",
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "competitionReopening": {
-              "title": "Reopening of the competition in the framework agreement",
-              "description": "Whether or not the competition is reopened for each subsequent contract of the framework agreement.",
-              "type": [
-                "string",
-                "null"
-              ],
-              "openCodelist": false,
-              "codelist": "frameworkAgreementCompetition.csv"
-            },
-            "durationRationale": {
-              "title": "Framework agreement duration rationale",
-              "description": "The justification for exceptional cases when the duration of framework agreements exceeds the legal limits.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "buyerCategories": {
-              "title": "Framework agreement buyer categories",
-              "description": "Any additional categories of buyers participating in the framework agreement and not mentioned by name (e.g. 'all hospitals in the Tuscany region').",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "dynamicPurchasingSystem": {
-              "title": "Dynamic purchasing system",
-              "description": "Whether a dynamic purchasing system is involved and, in case of central purchasing bodies, whether it can be used by buyers not listed in this procedure.",
-              "type": [
-                "string",
-                "null"
-              ],
-              "openCodelist": false,
-              "codelist": "dynamicPurchasingSystem.csv"
-            }
-          }
-        },
-        "electronicAuction": {
-          "title": "Electronic auction",
-          "description": "Whether or not an electronic auction is used.",
+        "hasFrameworkAgreement": {
+          "title": "Framework agreement involved",
+          "description": "Whether a framework agreement is involved.",
           "type": [
             "boolean",
             "null"
           ]
         },
-        "electronicAuctionURL": {
-          "title": "Electronic auction URL",
+        "frameworkAgreement": {
+          "title": "Framework agreement",
+          "description": "Information about the framework agreement.",
+          "$ref": "#/definitions/FrameworkAgreement"
+        },
+        "hasDynamicPurchasingSystem": {
+          "title": "Dynamic purchasing system involved",
+          "description": "Whether a dynamic purchasing system is involved.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dynamicPurchasingSystem": {
+          "title": "Dynamic purchasing system",
+          "description": "Information about the dynamic purchasing system.",
+          "$ref": "#/definitions/DynamicPurchasingSystem"
+        },
+        "hasElectronicAuction": {
+          "title": "Electronic auction used",
+          "description": "Whether an electronic auction is used.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "electronicAuction": {
+          "title": "Electronic auction",
+          "description": "Information about the electronic auction.",
+          "$ref": "#/definitions/ElectronicAuction"
+        }
+      }
+    },
+    "FrameworkAgreement": {
+      "title": "Framework agreement",
+      "description": "Information about the framework agreement.",
+      "type": "object",
+      "properties": {
+        "maximumNumberParticipants": {
+          "title": "Maximum number of participants",
+          "description": "The maximum number of participants in the framework agreement. If there is no maximum, set to 1e9999 (which parses to infinity).",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "method": {
+          "title": "Method",
+          "description": "Whether contracts are awarded with, without, or both with and without the reopening of competition.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "openCodelist": false,
+          "codelist": "frameworkAgreementMethod.csv",
+          "enum": [
+            "withReopeningCompetition",
+            "withoutReopeningCompetition",
+            "withAndWithoutReopeningCompetition",
+            null
+          ]
+        },
+        "durationRationale": {
+          "title": "Duration rationale",
+          "description": "The justification for exceptional cases when the duration of a framework agreement exceeds the legal limits.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "buyerCategories": {
+          "title": "Buyer categories",
+          "description": "Any additional categories of buyers participating in the framework agreement and not mentioned by name (e.g. 'all hospitals in the Tuscany region').",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "DynamicPurchasingSystem": {
+      "title": "Dynamic purchasing system",
+      "description": "Information about the dynamic purchasing system.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "In the case of central purchasing bodies, whether the dynamic purchasing system can be used by buyers not listed in the contracting process.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "openCodelist": false,
+          "codelist": "dynamicPurchasingSystemType.csv",
+          "enum": [
+            "open",
+            "closed",
+            null
+          ]
+        }
+      }
+    },
+    "ElectronicAuction": {
+      "title": "Electronic auction",
+      "description": "Information about the electronic auction.",
+      "type": "object",
+      "properties": {
+        "url": {
+          "title": "URL",
           "description": "The internet address of the electronic auction.",
           "type": [
             "string",
             "null"
           ]
         },
-        "electronicAuctionDescription": {
-          "title": "Electronic auction description",
+        "description": {
+          "title": "Description",
           "description": "Any additional information about the electronic auction.",
           "type": [
             "string",
             "null"
           ]
-      },
-      "electronicCatalogue": {
-          "title": "Electronic catalogue required",
-          "description": "Whether tenderers are required, allowed or not allowed to submit (parts of) bids as electronic catalogues.",
-          "type": ["string","null"],
-          "openCodelist": false,
-          "codelist": "electronicCatalogue.csv"
-      }
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #2

Readme

* Put EU-specific content in "Legal context" section
* Add examples
* Add links

Codelists

* Remove empty Deprecated columns
* dynamicPurchasingSystemType.csv
  * Avoid repeating `dps` in code
  * DPS's are not necessarily involved in the context of a framework agreement
  * Semantically separate the type of DPS from whether a DPS is used
  * Rename from dynamicPurchasingSystem.csv
* frameworkAgreementMethod.csv
  * Use longer codes
  * Rephrase description in terms of how contracts are awarded, and give synonyms
  * Rename from frameworkAgreementCompetition.csv

Schema

* Extend Lot instead of Tender
* Add `hasSomeField` and `someField` pairs for each technique
* Use Participants instead of SelectedTenderers, to avoid confusion with tenderers in tender stage
* Avoid using the sentinel value `0` to indicate infinity. Instead, use 1e9999, which is parsed as infinity by common JSON parsers
* Rename `competitionReopening` to `method`, since it describes the method through which contracts are awarded
* Remove repetition of definition name in field title
* Change `dynamicPurchasingSystem` into an object with a field of `type`, in case additional fields are added in future
* Remove `electronicCatalogue` as it is a submission term, not a technique
